### PR TITLE
feat: make directinput-based arcade joystick configurable

### DIFF
--- a/EXVS2-POC/JvsEmu.cpp
+++ b/EXVS2-POC/JvsEmu.cpp
@@ -433,40 +433,31 @@ int handleReadSwitchInputs(jprot_encoder *r)
 				byte1 |= static_cast<char>(1 << 3);
 				byte1 |= static_cast<char>(1 << 5);
 			}
-			if (joy.dwButtons & 1)
+			int intJoyDwButtons = (int) joy.dwButtons;
+			if (intJoyDwButtons & key_bind.ArcadeButton1)
 			{
 				log("Button 1 Detected from Joystick");
 				byte1 |= static_cast<char> (1 << 1);
 			}
-			if (joy.dwButtons & 8)
+			if (intJoyDwButtons & key_bind.ArcadeButton2)
 			{
 				log("Button 2 Detected from Joystick");
 				byte1 |= static_cast<char> (1);
 			}
-			if (joy.dwButtons & 32)
+			if (intJoyDwButtons & key_bind.ArcadeButton3)
 			{
 				log("Button 3 Detected from Joystick");
 				byte2 |= static_cast<char> (1 << 7);
 			}
-			if (joy.dwButtons & 2)
+			if (intJoyDwButtons & key_bind.ArcadeButton4)
 			{
 				log("Button 4 Detected from Joystick");
 				byte2 |= static_cast<char> (1 << 6);
 			}
-			if (joy.dwButtons & 512)
+			if (intJoyDwButtons & key_bind.ArcadeStartButton)
 			{
 				log("Start Button Detected from Joystick");
 				byte1 |= static_cast<char>(1 << 7);
-			}
-			if (joy.dwButtons & 16)
-			{
-				log("Service Button Detected from Joystick");
-				byte1 |= static_cast<char>(1 << 6);
-			}
-			if (joy.dwButtons & 64)
-			{
-				log("Test Button Detected from Joystick");
-				byte0 |= static_cast<char>(1 << 7);
 			}
 		}
 	}

--- a/EXVS2-POC/JvsEmu.h
+++ b/EXVS2-POC/JvsEmu.h
@@ -12,6 +12,11 @@ struct jvs_key_bind {
 	int Button2;
 	int Button3;
 	int Button4;
+	int ArcadeButton1;
+	int ArcadeButton2;
+	int ArcadeButton3;
+	int ArcadeButton4;
+	int ArcadeStartButton;
 };
 
 void InitializeJvs(jvs_key_bind keyBind);

--- a/EXVS2-POC/dllmain.cpp
+++ b/EXVS2-POC/dllmain.cpp
@@ -54,6 +54,21 @@ config_struct ReadConfigs(INIReader reader) {
     keyMapPlaceholder = reader.Get("keybind", "Button4", "V");
     key_bind.Button4 = findKeyByValue(keyMapPlaceholder);
 
+    keyMapPlaceholder = reader.Get("keybind", "ArcadeButton1", "1");
+    key_bind.ArcadeButton1 = std::stoi(keyMapPlaceholder);
+
+    keyMapPlaceholder = reader.Get("keybind", "ArcadeButton2", "2");
+    key_bind.ArcadeButton2 = std::stoi(keyMapPlaceholder);
+    
+    keyMapPlaceholder = reader.Get("keybind", "ArcadeButton3", "3");
+    key_bind.ArcadeButton3 = std::stoi(keyMapPlaceholder);
+
+    keyMapPlaceholder = reader.Get("keybind", "ArcadeButton4", "4");
+    key_bind.ArcadeButton4 = std::stoi(keyMapPlaceholder);
+
+    keyMapPlaceholder = reader.Get("keybind", "ArcadeStartButton", "5");
+    key_bind.ArcadeStartButton = std::stoi(keyMapPlaceholder);
+
     config.key_bind = key_bind;
     return config;
 }


### PR DESCRIPTION
As per description.

The keybind config has been added with:
#ArcadeButtons are for DirectInput Joysticks, you can figure out the key (integer) by using JoystickDetection.exe
ArcadeButton1 = 1
ArcadeButton2 = 8
ArcadeButton3 = 32
ArcadeButton4 = 2
ArcadeStartButton = 512 