### PR TITLE
Clean up config.

### DIFF
--- a/EXVS2-POC/Configs.h
+++ b/EXVS2-POC/Configs.h
@@ -17,9 +17,9 @@
 	KEYBIND(B, "X", "4") \
 	KEYBIND(C, "C", "6") \
 	KEYBIND(D, "V", "2") \
-	KEYBIND(Start, "1", "10") \
-	KEYBIND(Coin, "M", "13") \
-	KEYBIND(Card, "P", "7") \
+	KEYBIND(Start, "1", "") \
+	KEYBIND(Coin, "M", "") \
+	KEYBIND(Card, "P", "") \
 	KEYBIND(Test, "T", "") \
 	KEYBIND(Service, "S", "") \
 	KEYBIND(Kill, "Esc", "") \

--- a/EXVS2-POC/config.ini
+++ b/EXVS2-POC/config.ini
@@ -15,23 +15,18 @@ InterfaceName = Ethernet
 Server = 127.0.0.1
 
 # Boot the game in windowed mode or not
-windowed = true
+Windowed = true
 
 # Region code, refer to https://dash-dash-dash.jp/archives/57210.html for valid values.
 Region = 1
-
-# Possible Modes for InputMode (refer to bottom of this config for more detailed control info.)
-# 1. None
-# 2. Keyboard
-# 3. DirectInputOnly
-# 4. DirectInput (DirectInput + Keyboard)
-InputMode = DirectInput
 
 # Keyboard and DirectInput bindings each have their own sections.
 # Multiple bindings can be set for an input by comma-separating them.
 # If a bound key/button is assigned for multiple inputs, it functions as a macro:
 # e.g. bind a button to A, B, and C for burst.
 [keyboard]
+Enabled = true
+
 Up = UpArr,W
 Left = LeftArr,A
 Down = DownArr,S
@@ -50,7 +45,7 @@ Service = F2
 
 Kill = Esc
 
-[dinput]
+[controller]
 # DirectInput supports all of the keyboard inputs.
 # Button IDs match the ones in the Windows "Set up USB game controllers" control panel.
 # If you're using a PS4 controller, the button numbers should be the following.
@@ -68,6 +63,8 @@ Kill = Esc
 #   12 = R3
 #   13 = Home
 #   14 = Trackpad
+Enabled = true
+
 A = 1
 B = 4
 C = 6

--- a/EXVS2-POC/config.ini
+++ b/EXVS2-POC/config.ini
@@ -1,10 +1,10 @@
 [config]
-# Serial for dongle
-serial = 284311110001
-# Pcbid, digits are the last 7 digits from serial
-PcbId = ABLN1110001
-# Game mode, 1 for client, 2 for LM, need corresponding serial, 28431111xxxx for LM and 28431411xxxx for client
-mode = 2
+# Game mode, Client or LM.
+Mode = Client
+
+# Four digit serial number for store-to-store matchmaking.
+# You don't need to touch this.
+Serial = 0001
 
 # Specify either an IP address or the name of an interface to select the network interface to be used.
 # InterfaceName will match prefixes (i.e. "Ethernet" will match "Ethernet Connection")

--- a/EXVS2-POC/dllmain.cpp
+++ b/EXVS2-POC/dllmain.cpp
@@ -77,6 +77,15 @@ static config_struct ReadConfigs(INIReader reader) {
     {
         fatal("Unknown log level '%s'", logLevel.c_str());
     }
+    if (g_logLevel != LogLevel::NONE)
+    {
+        AllocConsole();
+
+        FILE* dummy;
+        freopen_s(&dummy, "CONIN$", "r", stdin);
+        freopen_s(&dummy, "CONOUT$", "w", stderr);
+        freopen_s(&dummy, "CONOUT$", "w", stdout);
+    }
 
     config.Windowed = reader.GetBoolean("config", "windowed", false);
     config.PcbId = reader.Get("config", "PcbId", "ABLN1110001");
@@ -171,16 +180,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
             }
 
             globalConfig = ReadConfigs(reader);
-
-            if (g_logLevel != LogLevel::NONE)
-            {
-                AllocConsole();
-
-                FILE* dummy;
-                freopen_s(&dummy, "CONIN$", "r", stdin);
-                freopen_s(&dummy, "CONOUT$", "w", stderr);
-                freopen_s(&dummy, "CONOUT$", "w", stdout);
-            }
 
             MH_Initialize();
             InitializeSocketHooks();

--- a/EXVS2-POC/dllmain.cpp
+++ b/EXVS2-POC/dllmain.cpp
@@ -107,10 +107,15 @@ static config_struct ReadConfigs(INIReader reader) {
     }
 
     bool validLength = config.Serial.size() == 12;
-    if (config.Mode == 1 && (!validLength || !config.Serial.starts_with("28431411"))) {
-      fatal("invalid serial: expected serial of format 28431411XXXX for client");
-    } else if (config.Mode == 2 && (!validLength || !config.Serial.starts_with("28431111"))) {
-      fatal("invalid serial: expected serial of format 28431111XXXX for LM");
+    bool validClientPrefix = config.Serial.starts_with("28431411") || config.Serial.starts_with("28431311");
+    bool validLMPrefix = config.Serial.starts_with("28431111");
+    if (config.Mode == 1 && (!validLength || !validClientPrefix))
+    {
+        fatal("invalid serial: expected serial of format 28431411XXXX/28431311XXXX for client");
+    }
+    else if (config.Mode == 2 && (!validLength || !validLMPrefix))
+    {
+        fatal("invalid serial: expected serial of format 28431111XXXX for LM");
     }
 
     config.PcbId = reader.GetOptional("config", "PcbId").value_or("ABLN1" + config.Serial.substr(5));

--- a/EXVS2-POC/dllmain.cpp
+++ b/EXVS2-POC/dllmain.cpp
@@ -110,40 +110,23 @@ static config_struct ReadConfigs(INIReader reader) {
 #undef KEYBIND
 
     KeyBinds dinput;
-#define KEYBIND(name, kb_default, dinput_default)                                                   \
-    {                                                                                               \
-        std::vector<std::string> keys = Split(reader.Get("dinput", #name, dinput_default), ',');    \
-        for (const auto& key : keys) {                                                              \
-            dinput.name.push_back(atoi(key.c_str()));                                               \
-        }                                                                                           \
+#define KEYBIND(name, kb_default, dinput_default)                                                                      \
+    {                                                                                                                  \
+        std::vector<std::string> keys = Split(reader.Get("controller", #name, dinput_default), ',');                   \
+        for (const auto& key : keys)                                                                                   \
+        {                                                                                                              \
+            dinput.name.push_back(atoi(key.c_str()));                                                                  \
+        }                                                                                                              \
     }
     KEYBINDS()
 #undef KEYBIND
 
-    std::string inputMode = reader.Get("config", "InputMode", "Keyboard");
-    if (inputMode == "None")
-    {
-        config.InputMode = InputModeNone;
-    }
-    else if (inputMode == "Keyboard")
-    {
-        config.InputMode = InputModeKeyboard;
-    }
-    else if (inputMode == "DirectInputOnly")
-    {
-        config.InputMode = InputModeDirectInput;
-    }
-    else if (inputMode == "DirectInput")
-    {
-        config.InputMode = InputModeBoth;
-    }
-    else
-    {
-        fatal("unknown InputMode: %s (supported values: None, Keyboard, DirectInputOnly, DirectInput)", inputMode.c_str());
-    }
+    int keyboardEnabled = reader.GetBoolean("keyboard", "Enabled", true);
+    int controllerEnabled = reader.GetBoolean("controller", "Enabled", true);
+    config.InputMode = static_cast<InputMode>(controllerEnabled << 1 | keyboardEnabled);
 
     // TODO: This should take a GUID instead of an index.
-    config.DirectInputDeviceId = reader.GetInteger("dinput", "DeviceId", 16);
+    config.DirectInputDeviceId = reader.GetInteger("controller", "DeviceId", 16);
     config.DirectInputBindings = dinput;
     config.KeyboardBindings = keyboard;
     return config;


### PR DESCRIPTION
 - rename dinput to controller, for when we make the input stack capable of handling xinput devices as well
 - accept `mode = client`/`mode = lm` instead of having to either keep a comment around or remember that 1 means lm and 2 means client
 - generate PcbId from mode + serial
 - support generating the rest of serial from a four digit serial (full serials are supported still for compatibility with scripting)